### PR TITLE
Add Dependabot workflow

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,7 +8,8 @@ updates:
       - dependency-name: "org.projectlombok:lombok"
       - dependency-name: "com.diffplug.spotless:spotless-maven-plugin"
     groups: # Group so it can create a single PR for all dependencies
-      all-dependencies:
+      security-updates: # Group name for security updates
+        applies-to: security-updates
         patterns:
           - "*"
     assignees:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,15 @@
+version: 2
+updates:
+  - package-ecosystem: "maven"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    ignore: # Ignore some dependencies that are only used for development
+      - dependency-name: "org.projectlombok:lombok"
+      - dependency-name: "com.diffplug.spotless:spotless-maven-plugin"
+    groups: # Group so it can create a single PR for all dependencies
+      all-dependencies:
+        patterns:
+          - "*"
+    assignees:
+      - "AadiManchekar"


### PR DESCRIPTION
- Add Dependabot github workflow to only raise pull request for dependency's security updates.
- Automatically raise a single pull requests for all dependencies.
- @AadiManchekar is automatically marked as assignee for PR raised by Depandabot.

References:
- https://docs.github.com/en/code-security/getting-started/dependabot-quickstart-guide
- https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/optimizing-pr-creation-version-updates
- https://docs.github.com/en/code-security/dependabot/dependabot-security-updates/configuring-dependabot-security-updates