### PR TITLE
Integrate Kafka, Zookeeper and Kafka-ui services to Docker Compose configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -340,19 +340,6 @@ While setting up healthchecks for containers, I faced a couple of interesting ch
   - If `grep` finds the string, it exits with code `0` (success), signaling the container is healthy.
   - If not found, `grep` exits with code `1` (failure), marking the container as unhealthy.
 
-- **Kafka Healthcheck:**  
-  For Kafka, I used the following healthcheck to ensure the broker is up and responding:
-  ```yaml
-  healthcheck:
-    test: kafka-cluster.sh cluster-id --bootstrap-server localhost:9092 || exit 1
-    interval: 30s
-    timeout: 10s
-    retries: 3
-  ```
-  **How it works:**  
-  - `kafka-cluster.sh cluster-id --bootstrap-server localhost:9092` attempts to fetch the Kafka cluster ID.
-  - If the command succeeds (exit code `0`), the healthcheck passes and the container is considered healthy.
-  - If the command fails (e.g., Kafka is not ready), it returns a non-zero exit code, so `|| exit 1` ensures the healthcheck fails with exit code `1`.   
 
 ---
 
@@ -413,6 +400,11 @@ Vault is used to securely store both static and dynamic secrets for the Fleet ap
     - https://gist.github.com/Mishco/b47b341f852c5934cf736870f0b5da81
     - https://hub.docker.com/r/hashicorp/vault
 
+8. **Kafka and ZooKeeper Setup**
+  - Setting up a reliable Kafka environment was crucial for Fleet's event-driven architecture. Learning how to properly configure Kafka and ZooKeeper in Docker Compose presented challenges, particularly with setting proper environment-variables, healthchecks etc. I'm using **Confluent Kafka and Zookeeper** as many enterpises are utilizing it.
+
+  - Links referred:
+    - https://www.geeksforgeeks.org/getting-started-with-spring-boot-3-kafka-over-docker-with-docker-composeyaml/
 ---
 
 ## Installation 🛠️

--- a/tools/build/compile.sh
+++ b/tools/build/compile.sh
@@ -22,23 +22,23 @@ cd $(dirname "$0")/../../
 echo -e "\033[0;33mDIRECTORY: $(pwd)\033[0m"  # Dark yellow
 print_line_break
 
-# MVN CLEAN
-echo -e "\033[0;32mACTION: mvn clean\033[0m"  # Dark green
-print_line_break
-echo "Cleaning up old build files..."
-mvn clean
-print_line_break
-
 # If running in GitHub CI, skip docker compose up
 if [ "$GITHUB_ACTIONS" != "true" ]; then
     echo -e "\033[0;32mACTION: docker compose up -d\033[0m"  # Dark green
     print_line_break
     echo "Starting up the docker compose..."
     cd tools/docker
-    docker-compose up -d
+    docker compose up -d
     cd ../..
     print_line_break
 fi
+
+# MVN CLEAN
+echo -e "\033[0;32mACTION: mvn clean\033[0m"  # Dark green
+print_line_break
+echo "Cleaning up old build files..."
+mvn clean
+print_line_break
 
 # MVN INSTALL
 echo -e "\033[0;32mACTION: mvn install\033[0m"  # Dark green
@@ -51,7 +51,7 @@ if [ "$GITHUB_ACTIONS" != "true" ]; then
     print_line_break
     echo "Stopping the docker compose..."
     cd tools/docker
-    docker-compose down
+    docker compose down
     cd ../..
     print_line_break
 fi

--- a/tools/docker/docker-compose.yaml
+++ b/tools/docker/docker-compose.yaml
@@ -1,5 +1,45 @@
 ---
 services:
+  zookeeper:
+    image: wurstmeister/zookeeper:latest
+    container_name: zookeeper-0
+    ports:
+    - 2181:2181
+  kafka:
+    image: wurstmeister/kafka:latest
+    container_name: kafka-0
+    ports:
+    - 9092:9092
+    healthcheck:
+      test: kafka-cluster.sh cluster-id --bootstrap-server localhost:9092 || exit
+        1
+      interval: 30s
+      timeout: 10s
+      retries: 3
+    environment:
+      KAFKA_LISTENERS: PLAINTEXT://0.0.0.0:9092
+      KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://kafka:9092
+      KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181
+    depends_on:
+    - zookeeper
+  kafka-ui:
+    image: provectuslabs/kafka-ui:v0.7.2
+    container_name: kafka-ui
+    ports:
+    - 7080:8080
+    healthcheck:
+      test:
+      - CMD-SHELL
+      - wget -qO- http://localhost:8080/actuator/health | grep -q '"status":"UP"'
+      interval: 30s
+      timeout: 10s
+      retries: 3
+    environment:
+      KAFKA_CLUSTERS_0_NAME: fleet-kafka
+      KAFKA_CLUSTERS_0_BOOTSTRAPSERVERS: kafka:9092
+    depends_on:
+      kafka:
+        condition: service_healthy
   vault:
     image: hashicorp/vault:1.19
     container_name: vault-0

--- a/tools/docker/docker-compose.yaml
+++ b/tools/docker/docker-compose.yaml
@@ -1,27 +1,41 @@
 ---
 services:
   zookeeper:
-    image: wurstmeister/zookeeper:latest
+    image: confluentinc/cp-zookeeper:7.9.1
     container_name: zookeeper-0
     ports:
     - 2181:2181
+    healthcheck:
+      test: nc -z localhost 2181 || exit -1
+      interval: 10s
+      timeout: 10s
+      retries: 6
+    environment:
+      ZOOKEEPER_TICK_TIME: 2000
+      ZOOKEEPER_CLIENT_PORT: 2181
   kafka:
-    image: wurstmeister/kafka:latest
+    image: confluentinc/cp-kafka:7.9.1
     container_name: kafka-0
     ports:
     - 9092:9092
     healthcheck:
-      test: kafka-cluster.sh cluster-id --bootstrap-server localhost:9092 || exit
-        1
-      interval: 30s
+      test:
+      - CMD
+      - kafka-topics
+      - --bootstrap-server
+      - kafka:9092
+      - --list
+      interval: 10s
       timeout: 10s
-      retries: 3
+      retries: 6
     environment:
-      KAFKA_LISTENERS: PLAINTEXT://0.0.0.0:9092
-      KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://kafka:9092
+      KAFKA_AUTO_CREATE_TOPICS_ENABLE: "true"
       KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181
+      KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://kafka:9092
+      KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: PLAINTEXT:PLAINTEXT
     depends_on:
-    - zookeeper
+      zookeeper:
+        condition: service_healthy
   kafka-ui:
     image: provectuslabs/kafka-ui:v0.7.2
     container_name: kafka-ui
@@ -31,9 +45,9 @@ services:
       test:
       - CMD-SHELL
       - wget -qO- http://localhost:8080/actuator/health | grep -q '"status":"UP"'
-      interval: 30s
+      interval: 10s
       timeout: 10s
-      retries: 3
+      retries: 6
     environment:
       KAFKA_CLUSTERS_0_NAME: fleet-kafka
       KAFKA_CLUSTERS_0_BOOTSTRAPSERVERS: kafka:9092


### PR DESCRIPTION
* Integrate Kafka, Zookeeper and Kafka-UI services into the Docker Compose with proper health checks.
* Update README.MD to add new challenges faced.
* Remove obsolete use of docker-compose command and use docker compose instead.
* Rearrange compile.sh to run docker compose up first then all mvn commands.
