### PR TITLE
Upgrade Java version from 17 to 21

### DIFF
--- a/.github/workflows/github-ci.yaml
+++ b/.github/workflows/github-ci.yaml
@@ -17,14 +17,14 @@ jobs:
     strategy:
       matrix:
         java-version:
-        - 17
+        - 21
     steps:
     - name: Checkout Repository
       uses: actions/checkout@v4
-    - name: Set up JDK 17
+    - name: Set up JDK 21
       uses: actions/setup-java@v4
       with:
-        java-version: 17
+        java-version: 21
         distribution: temurin
         cache: maven
     - name: Resolve Maven Dependencies and Plugins

--- a/pom.xml
+++ b/pom.xml
@@ -45,7 +45,7 @@
         <grpc.version>1.70.0</grpc.version>
         <jackson-databind>2.18.3</jackson-databind>
         <jacoco-maven-plugin>0.8.13</jacoco-maven-plugin>
-        <java.version>17</java.version>
+        <java.version>21</java.version>
         <maven-clean-plugin>3.4.1</maven-clean-plugin>
         <maven-resources-plugin>3.3.1</maven-resources-plugin>
         <maven-surefire-plugin>3.5.3</maven-surefire-plugin>


### PR DESCRIPTION
* Since there are no child modules hence not much change is observed.
* Update GitHub CI configuration to use JDK 21

Links referred o upgrade java from 17 to 21:
- https://hkcodeblogs.medium.com/upgrade-springboot-applications-to-latest-version-in-10-minutes-9bd141d02498
- https://spring.io/blog/2023/09/20/hello-java-21/